### PR TITLE
El agente atiende WhatsApp, con Chatwoot en el medio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,41 +95,58 @@ TELEGRAM_TOKEN=
 
 
 # ===========================================================================
-#  5. CUANDO EL AGENTE ATIENDA WHATSAPP  (todavía no hace falta)
+#  5. WHATSAPP  (con Chatwoot en el medio)
 # ===========================================================================
 #
-# Nada de esto se usa todavía. Están acá para que sepas qué va a hacer falta
-# cuando lo conectes a WhatsApp, y para que el .env no cambie de forma en el
-# camino.
+# Esto es para  python webhook_chatwoot.py  y necesita un servidor con
+# dominio: WhatsApp va por webhook, así que alguien tiene que poder entrar.
+# Si solo vas a usar la terminal, la web o Telegram, saltealo entero.
 #
-# Descomentá solo las que uses.
+# El recorrido de un mensaje:
+#
+#   persona → WhatsApp → Meta → Chatwoot → tu webhook → el agente
+#                                  ↑                        │
+#                                  └──── la respuesta ──────┘
+#
+# Ojo con esto, que ahorra tiempo: **el agente NO le habla a Meta**, le habla
+# a Chatwoot. Por eso acá no hay token de WhatsApp, ni App Secret, ni firma
+# HMAC: de eso se encarga Chatwoot cuando conectás el inbox. Vos solo
+# necesitás las cuatro variables de abajo.
 
 
-# --- WhatsApp (Meta) ---
-# Lo que configurás en el panel de Meta
-# WHATSAPP_TOKEN=
-# WHATSAPP_TELEFONO_ID=
-# WHATSAPP_VERIFY_TOKEN=
-# Con esto se verifica que el mensaje venga de Meta de verdad y no de
-# cualquiera que descubrió tu URL. NO es opcional en producción.
-# WHATSAPP_APP_SECRET=
+# --- Chatwoot ---
+# La dirección de tu Chatwoot, con https:// (la barra final da igual)
+CHATWOOT_URL=
+# Perfil → Configuración del perfil → Token de acceso a la API
+CHATWOOT_TOKEN=
+# El número que aparece en la URL cuando entrás: /app/accounts/1/...
+CHATWOOT_CUENTA_ID=1
+
+# El secreto que va en la URL del webhook:
+#
+#   https://tu-dominio.com/chatwoot/<CHATWOOT_WEBHOOK_TOKEN>
+#
+# Chatwoot NO firma sus webhooks, así que esto es lo único que separa un
+# mensaje de verdad de cualquiera que descubra tu dominio. Generá uno largo
+# y al azar, no lo escribas a mano:
+#
+#   python -c "import secrets; print(secrets.token_hex(24))"
+#
+CHATWOOT_WEBHOOK_TOKEN=
+
+# Etiqueta que apaga al bot en una conversación (el traspaso a una persona).
+# Se la ponés desde la bandeja y el agente se calla en ese chat.
+CHATWOOT_ETIQUETA_HUMANO=humano
 
 
-# --- Chatwoot (opcional) ---
-# Si lo usás, el agente atiende desde la bandeja de Chatwoot: tenés el
-# historial, el multicanal y podés sacarle la conversación al bot poniéndole
-# una etiqueta. Si lo dejás vacío, el agente habla directo con el canal.
-# CHATWOOT_URL=
-# CHATWOOT_TOKEN=
-# CHATWOOT_CUENTA_ID=
-# Etiqueta que apaga al bot en una conversación (el traspaso a una persona)
-# CHATWOOT_ETIQUETA_HUMANO=humano
-
-
-# --- Redis: juntar los mensajes cortados ---
+# --- Juntar los mensajes cortados ---
 # La gente en WhatsApp escribe "hola" / "queria preguntar" / "por el precio"
-# en tres mensajes seguidos. Sin esto, el agente contesta tres veces.
-# Con esto, espera, los junta y contesta una sola vez.
-# REDIS_URL=redis://localhost:6379
-# Cuánto espera antes de dar por terminada la ráfaga
-# BUFFER_SEGUNDOS=6
+# en tres mensajes seguidos. Sin esto el agente contesta tres veces, y las
+# tres mal: recién el tercero trae la pregunta entera.
+#
+# Cuántos segundos espera juntando la ráfaga antes de contestar.
+# Con 0 contesta cada mensaje al toque (y se pisa).
+BUFFER_SEGUNDOS=8
+
+# El puerto donde escucha el webhook. En un contenedor dejalo en 8000.
+PUERTO=8000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,14 @@ Lo que importa acá es qué hace cada uno:
 | `respuesta.py` | Parte una respuesta larga en varios mensajes |
 | `consola.py` | Que la terminal de Windows no rompa con las tildes |
 | `config.py` | Lee el `.env`. Única fuente de configuración. |
-| `canales/base.py` | La forma de un canal. WhatsApp viene después. |
+| `canales/base.py` | La forma de un canal |
 | `canales/telegram.py` | **El bot de Telegram.** Polling, corre en tu máquina. |
-| `../Dockerfile` | Empaqueta **solo el bot** (`bot_telegram.py`), no la web |
-| `web/` | La plataforma de pruebas (FastAPI + un solo HTML) |
+| `canales/chatwoot.py` | **El canal de WhatsApp**, con Chatwoot en el medio |
+| `canales/buffer.py` | Junta la ráfaga de mensajes cortos y contesta una vez |
+| `web/webhook.py` | **El servidor que atiende WhatsApp.** Es lo que corre en producción. |
+| `../webhook_chatwoot.py` | El punto de entrada del webhook |
+| `../Dockerfile` | Empaqueta el **webhook** (`webhook_chatwoot.py`); el bot de Telegram queda adentro por si lo querés correr |
+| `web/app.py` | La plataforma de pruebas (FastAPI + un solo HTML) — **no es** el webhook |
 
 ---
 
@@ -120,10 +124,15 @@ La instalación paso a paso está en el
 desincronicen. Lo que hace falta saber:
 
 ```bash
-python servidor.py     # la plataforma de pruebas, en http://localhost:8000
-python chat.py         # lo mismo pero por terminal
-python bot_telegram.py # el agente atendiendo en Telegram (polling, local)
+python servidor.py         # la plataforma de pruebas, en http://localhost:8000
+python chat.py             # lo mismo pero por terminal
+python bot_telegram.py     # el agente atendiendo en Telegram (polling, local)
+python webhook_chatwoot.py # el agente atendiendo WhatsApp (necesita servidor)
 ```
+
+El último es el único que **no** sirve en tu máquina: es un webhook, así que
+Chatwoot tiene que poder entrar. Levantalo local solo para confirmar que
+arranca (`GET /salud`); para probarlo de verdad tiene que estar desplegado.
 
 El bot se llama `bot_telegram.py` y no `telegram.py` a propósito: un módulo
 llamado `telegram` en la raíz taparía la librería del mismo nombre si algún
@@ -198,10 +207,14 @@ Cosas que parecen bugs y no lo son, o que cuestan de encontrar:
   el bot se queda trabado ahí sin atender a nadie más.
 - **El `chat_id` va como texto** al usarse de `thread_id`. Un `555` y un
   `"555"` son dos conversaciones distintas para LangGraph.
-- **El bot no expone puerto y eso confunde a los PaaS.** Al desplegarlo, el
-  panel le asigna un dominio solo y después lo marca como *unhealthy* porque
-  nadie contesta ahí. No está roto: con polling nadie entra al bot, sale él.
-  Hay que borrarle el dominio y dejar el health check apagado.
+- **El bot de Telegram no expone puerto y eso confunde a los PaaS.** Al
+  desplegarlo, el panel le asigna un dominio solo y después lo marca como
+  *unhealthy* porque nadie contesta ahí. No está roto: con polling nadie
+  entra al bot, sale él. Hay que borrarle el dominio y dejar el health check
+  apagado. **Ojo que con el webhook de WhatsApp es al revés**: ese sí escucha
+  en el 8000, sí necesita dominio y sí tiene que tener el health check
+  prendido apuntando a `/salud`. Son dos formas opuestas de desplegar el
+  mismo repo, y el Dockerfile hoy trae la segunda.
 - **Dos instancias del bot se roban los mensajes.** Telegram le entrega cada
   mensaje a quien lo pide primero, así que si corren el servidor y la máquina
   local a la vez, las respuestas salen la mitad de cada lado. Es la falla más
@@ -242,7 +255,6 @@ Cosas que parecen bugs y no lo son, o que cuestan de encontrar:
 No lo agregues salvo que te lo pidan: son los próximos videos de la serie.
 
 - Más herramientas (hay una sola: el clima)
-- WhatsApp (Telegram ya está: `canales/telegram.py`)
 - RAG / base de conocimiento
 - Autenticación en la plataforma de pruebas (es local, un solo usuario)
 - Varias conversaciones en paralelo en la web (usa un `thread_id` fijo)
@@ -342,26 +354,43 @@ imposible después.
 uno sin dominio ni puertos abiertos. Sirve igual con `MODO=test` (SQLite) que
 con `MODO=produccion` (Postgres): el agente no cambia.
 
-**Video 3 — WhatsApp.** `canales/whatsapp.py`, y ahí entra todo lo que
-separa un bot de demo de uno que atiende clientes:
+**Video 3 — WhatsApp. ✅ Hecho, con Chatwoot en el medio.**
 
-| Pieza | Dónde va | Por qué |
+El agente **no le habla a Meta**: le habla a Chatwoot, que ya está conectado
+a WhatsApp. Eso cambia el diseño respecto de lo que decía este archivo antes,
+y para mejor: la mitad de las piezas las resuelve Chatwoot.
+
+    persona → WhatsApp → Meta → Chatwoot → webhook → agente
+                                   ↑                    │
+                                   └──── API REST ──────┘
+
+| Pieza | Dónde quedó | Cómo se resolvió |
 |---|---|---|
-| Verificar la firma de Meta (HMAC-SHA256 con el App Secret) | `canales/whatsapp.py` | Sin esto cualquiera que sepa la URL le escribe al agente. **No es opcional.** |
-| Responder 200 en menos de 5s y procesar aparte | `canales/whatsapp.py` | Meta reintenta y el agente contesta de más |
-| Descartar el mensaje repetido por id | `Canal.deberia_responder()` | Meta reenvía ante la duda |
-| Juntar la ráfaga de mensajes (Redis) | `buffer.py` (nuevo) | La gente manda 3 mensajes cortos seguidos; hay que contestar una vez |
-| Partir la respuesta en varios globos | `respuesta.partir_respuesta()` | **Ya está hecho** |
-| Traspaso a una persona | `Canal.deberia_responder()` | Etiqueta en Chatwoot, o un flag propio. Es *el* diferencial |
-| Apagar el bot por contacto | `Canal.deberia_responder()` | |
-| Chatwoot **opcional** | `canales/chatwoot.py` | Si hay `CHATWOOT_URL` se usa; si no, el canal habla directo |
-| Ventana de 24h y plantillas | `canales/whatsapp.py` | Fuera de plazo, Meta rechaza el envío |
+| Autenticar quién llama al webhook | `web/webhook.py` | Chatwoot **no firma** sus webhooks (no hay HMAC como en Meta): la seguridad es un token secreto en la URL, `CHATWOOT_WEBHOOK_TOKEN` |
+| Responder 200 rápido y procesar aparte | `web/webhook.py` | El 200 sale antes de pensar la respuesta; si no, Chatwoot reintenta y el agente contesta de más |
+| Descartar el mensaje repetido por id | `Chatwoot.deberia_responder()` | Cola de los últimos 1.000 ids |
+| **Que el agente no se conteste a sí mismo** | `Chatwoot.deberia_responder()` | Solo se atiende `message_type == "incoming"`. Sin esto es un ida y vuelta infinito que gasta tokens en cada vuelta |
+| Juntar la ráfaga de mensajes | `canales/buffer.py` | En memoria, no Redis: hay un solo proceso atendiendo. `BUFFER_SEGUNDOS` |
+| Partir la respuesta en varios globos | `respuesta.partir_respuesta()` | Ya estaba |
+| Traspaso a una persona | `Chatwoot.deberia_responder()` | La etiqueta `CHATWOOT_ETIQUETA_HUMANO` apaga al bot en esa conversación, con un clic desde la bandeja |
+| Notas privadas | `Chatwoot.deberia_responder()` | Son para el equipo: el agente no las contesta |
+| Ventana de 24h y plantillas | Lo maneja Chatwoot | Por eso no está acá |
+
+**El `conversacion` (thread_id) es el id de conversación de Chatwoot.** Un
+hilo en la bandeja es un hilo de memoria del agente, y es también lo que se
+necesita para contestar: sirve para las dos cosas.
 
 **Decisiones ya tomadas** (no volver a discutirlas):
 
 - **Un solo repo.** Cada canal es un archivo nuevo; el núcleo no se toca.
-- **Chatwoot es opcional**, no obligatorio.
-- **Redis** para juntar los mensajes, no Postgres.
+  Se cumplió: `agente.py` no se tocó para que atienda WhatsApp.
+- **Chatwoot es opcional**, no obligatorio. El agente sigue andando por
+  terminal, web y Telegram sin él.
+- ~~**Redis** para juntar los mensajes~~ → **quedó en memoria**
+  (`canales/buffer.py`). Redis resolvía compartir la ráfaga entre varios
+  procesos, y hoy hay uno solo atendiendo. Sumar una base entera para eso era
+  pagar un problema que todavía no tenemos. Cuando se escale a varios
+  procesos se cambia esa clase y el webhook ni se entera.
 - **`MODO=test` responde y listo.** Todo lo de arriba corre solo en
   `MODO=produccion`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-# El agente atendiendo en Telegram, en un servidor.
+# El agente atendiendo WhatsApp, en un servidor.
 #
-# Esto NO levanta la plataforma de pruebas: corre `bot_telegram.py`, que es
-# un proceso que escucha Telegram y contesta. Por eso la imagen no abre
-# ningún puerto ni necesita dominio — el bot sale a buscar los mensajes
-# (polling), nadie entra a buscarlo a él.
+# Corre `webhook_chatwoot.py`: un servidor que espera a que Chatwoot le pegue
+# cuando llega un mensaje. A diferencia del bot de Telegram (que sale a buscar
+# los mensajes y no abre ningún puerto), este SÍ escucha en un puerto y
+# necesita dominio con HTTPS, porque acá entra alguien de afuera.
+#
+# El bot de Telegram también queda adentro de la imagen: si algún día querés
+# correr ese en vez de este, se cambia el CMD y nada más.
 #
 # Toda la configuración entra por variables de entorno. El .env no se copia
 # acá adentro: en el servidor las variables las pone Coolify.
@@ -11,14 +14,26 @@
 FROM python:3.13-slim
 
 # Sin esto, Python se guarda los logs en un buffer y en el panel del servidor
-# no ves nada hasta que el proceso muere. Con un bot que corre para siempre,
-# eso es no ver nunca nada.
+# no ves nada hasta que el proceso muere. Con un servidor que corre para
+# siempre, eso es no ver nunca nada.
 ENV PYTHONUNBUFFERED=1
 
 # Que las tildes no rompan cuando se imprime un mensaje.
 ENV PYTHONIOENCODING=utf-8
 
 WORKDIR /app
+
+# curl es para el health check del panel, no para la app.
+#
+# Coolify (y casi cualquier PaaS) revisa que el contenedor esté vivo pegándole
+# a una URL con curl o wget DESDE ADENTRO del contenedor. La imagen `slim` no
+# trae ninguno de los dos, así que sin esta línea el contenedor arranca bien,
+# atiende bien, y el panel igual lo marca *unhealthy* y lo da de baja. El log
+# que deja es "New container is not healthy, rolling back": no dice que falte
+# curl, y se pierde un rato largo buscando el error en otro lado.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Las dependencias primero y el código después: así, mientras no toques los
 # requirements, Docker reusa la capa ya instalada y el deploy tarda segundos
@@ -28,11 +43,16 @@ RUN pip install --no-cache-dir -r requirements-produccion.txt
 
 COPY src/ ./src/
 COPY prompts/ ./prompts/
-COPY bot_telegram.py ./
+COPY webhook_chatwoot.py bot_telegram.py ./
 
-# Sin esto corre como root sin necesidad: el bot no escribe nada en disco
-# (la memoria va a Postgres).
+# Sin esto corre como root sin necesidad: el servidor no escribe nada en
+# disco (la memoria va a Postgres).
 RUN useradd --create-home agente && chown -R agente:agente /app
 USER agente
 
-CMD ["python", "bot_telegram.py"]
+# El puerto donde escucha. Coolify lee este número para saber a dónde
+# mandarle el tráfico del dominio.
+ENV PUERTO=8000
+EXPOSE 8000
+
+CMD ["python", "webhook_chatwoot.py"]

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ gastás en cada mensaje.
 7. [El caché: gastar menos](#el-caché-gastar-menos)
 8. [El clima: la primera herramienta](#el-clima-la-primera-herramienta)
 9. [Ponerlo en Telegram](#ponerlo-en-telegram)
-10. [Dejarlo corriendo en un servidor](#dejarlo-corriendo-en-un-servidor)
-11. [Cambiar la personalidad](#cambiar-la-personalidad)
-12. [Usarlo desde tu código](#usarlo-desde-tu-código)
-13. [Todas las variables del .env](#todas-las-variables-del-env)
-14. [Preguntas que aparecen siempre](#preguntas-que-aparecen-siempre)
+10. [Ponerlo en WhatsApp](#ponerlo-en-whatsapp)
+11. [Dejarlo corriendo en un servidor](#dejarlo-corriendo-en-un-servidor)
+12. [Cambiar la personalidad](#cambiar-la-personalidad)
+13. [Usarlo desde tu código](#usarlo-desde-tu-código)
+14. [Todas las variables del .env](#todas-las-variables-del-env)
+15. [Preguntas que aparecen siempre](#preguntas-que-aparecen-siempre)
 
 ---
 
@@ -122,12 +123,17 @@ basdonax-ai-agentkit/
 │   ├── config.py           ← lee el .env
 │   ├── canales/
 │   │   ├── base.py         ← la forma de un canal
-│   │   └── telegram.py     ← EL BOT DE TELEGRAM
-│   └── web/                ← la plataforma de pruebas
-├── tests/                  ← 71 tests que no gastan un solo token
+│   │   ├── telegram.py     ← EL BOT DE TELEGRAM
+│   │   ├── chatwoot.py     ← EL CANAL DE WHATSAPP
+│   │   └── buffer.py       ← junta los mensajes cortos seguidos
+│   └── web/
+│       ├── app.py          ← la plataforma de pruebas
+│       └── webhook.py      ← el servidor que atiende WhatsApp
+├── tests/                  ← 103 tests que no gastan un solo token
 ├── chat.py                 ← hablarle desde la terminal
 ├── servidor.py             ← levantar la web
 ├── bot_telegram.py         ← levantar el bot de Telegram
+├── webhook_chatwoot.py     ← levantar el webhook de WhatsApp
 ├── AGENTS.md               ← contexto para Codex, Claude Code, Cursor…
 ├── CLAUDE.md               ← apunta a AGENTS.md
 └── .env                    ← tus claves (no se sube)
@@ -433,50 +439,194 @@ es un archivo y no le gusta que varios procesos le escriban al mismo tiempo.
 
 ---
 
+## Ponerlo en WhatsApp
+
+Acá el agente deja de ser una demo y pasa a atender clientes.
+
+**El agente no le habla a Meta: le habla a Chatwoot.** Esa es la decisión que
+hace que todo lo demás sea más fácil.
+
+```
+persona → WhatsApp → Meta → Chatwoot → tu webhook → el agente
+                               ↑                        │
+                               └──── la respuesta ──────┘
+```
+
+Qué te ahorra tener Chatwoot en el medio:
+
+- **No necesitás el token de WhatsApp, ni el App Secret, ni verificar la firma
+  HMAC de Meta.** Eso lo hace Chatwoot cuando conectás el inbox.
+- Te queda la **bandeja de entrada** con el historial y el buscador.
+- Una persona puede **meterse en la conversación** y seguirla a mano.
+- El mismo agente atiende Instagram o el widget de la web sin tocar una línea:
+  para el webhook, todo entra igual.
+
+Lo que sí necesitás: **un servidor con dominio y HTTPS**. WhatsApp va por
+webhook, así que alguien tiene que poder entrar. Esto no corre en tu compu.
+
+### 1. Conectá WhatsApp a Chatwoot
+
+En Chatwoot, **Configuración → Bandejas de entrada → Agregar** y elegí
+WhatsApp. Seguí los pasos con los datos de tu app de Meta.
+
+Cuando termines, mandate un mensaje al número desde tu teléfono: **si aparece
+en la bandeja, esta parte ya está.** No sigas hasta que eso funcione — todo lo
+demás depende de que Meta le esté entregando a Chatwoot.
+
+### 2. Completá el `.env`
+
+```bash
+CHATWOOT_URL=https://tu-chatwoot.com
+CHATWOOT_TOKEN=el-token-de-tu-perfil
+CHATWOOT_CUENTA_ID=1
+CHATWOOT_WEBHOOK_TOKEN=un-secreto-largo-y-al-azar
+```
+
+- **El token** sale de tu foto de perfil → *Configuración del perfil* → abajo
+  de todo, **Token de acceso a la API**.
+- **La cuenta** es el número que ves en la URL: `/app/accounts/1/...`
+- **El secreto del webhook** generalo, no lo escribas a mano:
+
+  ```bash
+  python -c "import secrets; print(secrets.token_hex(24))"
+  ```
+
+### 3. Desplegalo
+
+Está en [Dejarlo corriendo en un servidor](#dejarlo-corriendo-en-un-servidor).
+Cuando termine, entrá a `https://tu-dominio.com/salud`. Tiene que contestar:
+
+```json
+{"estado":"ok","proveedor":"openai","modelo":"...","memoria":"postgres"}
+```
+
+**Si eso no contesta, no sigas**: el webhook que vas a cargar en el paso 4 no
+va a tener a quién pegarle.
+
+### 4. El webhook, en Chatwoot
+
+En **Configuración → Integraciones → Webhooks → Agregar webhook**:
+
+| Campo | Qué va |
+|---|---|
+| URL | `https://tu-dominio.com/chatwoot/<CHATWOOT_WEBHOOK_TOKEN>` |
+| Eventos | **Solo `message_created`** |
+
+Dos avisos que valen el rato que ahorran:
+
+**Marcá únicamente `message_created`.** Si tildás todos, tu servidor recibe
+cada cambio de estado y cada actualización de contacto para nada.
+
+**El token va pegado en la URL, no en un campo aparte.** Chatwoot no firma sus
+webhooks —no tiene un secreto compartido como Meta—, así que esa tira en la
+dirección es lo único que separa un mensaje de verdad de cualquiera que
+descubra tu dominio. Si la URL no lo lleva, el agente contesta **401** y no
+pasa nada.
+
+### 5. La etiqueta `humano`
+
+En **Configuración → Etiquetas → Agregar etiqueta**, creá una que se llame
+exactamente **`humano`** (o lo que hayas puesto en `CHATWOOT_ETIQUETA_HUMANO`).
+
+Para qué sirve: se la ponés a una conversación desde la bandeja y **el agente
+se calla en ese chat**. Es el traspaso a una persona, y es *el* diferencial de
+tener Chatwoot — se hace con un clic, sin tocar el servidor ni reiniciar nada.
+Se la sacás y el bot vuelve.
+
+### Probalo
+
+Escribile al número desde tu teléfono. Vas a ver la respuesta en WhatsApp y en
+la bandeja de Chatwoot.
+
+Si no contesta, mirá los logs del contenedor: cada mensaje que entra deja una
+línea con el número de conversación y el texto.
+
+### Lo que ya está resuelto
+
+- **El agente no se contesta a sí mismo.** Cada respuesta suya vuelve por el
+  webhook como un evento nuevo; solo se atienden los `incoming`. Sin ese
+  filtro es un ida y vuelta infinito que gasta tokens en cada vuelta.
+- **Junta los mensajes cortados.** "hola" / "una consulta" / "por el precio"
+  es una sola respuesta, no tres (`BUFFER_SEGUNDOS`).
+- **Contesta 200 al toque** y piensa después. Si tardara lo que tarda el
+  modelo, Chatwoot daría el webhook por fallado y lo reintentaría — y el
+  agente contestaría dos veces.
+- **No repite** si Chatwoot reintenta el mismo mensaje.
+- **No contesta las notas privadas**: esas son del equipo.
+- **Cada conversación tiene su memoria**, con el id de Chatwoot como
+  `thread_id`.
+
+---
+
 ## Dejarlo corriendo en un servidor
 
-Hasta acá el bot vivía mientras tu computadora estuviera prendida. Para que
+Hasta acá el agente vivía mientras tu computadora estuviera prendida. Para que
 conteste siempre —desde el gimnasio, de viaje, a las 3 de la mañana— tiene que
 correr en un servidor.
 
-**La buena noticia: no hace falta dominio, ni HTTPS, ni abrir un puerto.** El
-bot usa polling, así que sale él a buscar los mensajes. Alcanza con un
-contenedor prendido.
+**Antes que nada: hay dos formas de desplegar este repo y son opuestas.** Es
+lo que más confunde, así que va en una tabla:
 
-El `Dockerfile` del repo hace justamente eso: **no levanta la plataforma de
-pruebas**, corre `bot_telegram.py` y nada más.
+|  | WhatsApp (`webhook_chatwoot.py`) | Telegram (`bot_telegram.py`) |
+|---|---|---|
+| Cómo llegan los mensajes | Chatwoot le pega a tu URL | El bot sale a buscarlos |
+| ¿Dominio? | **Sí, obligatorio** | **No, y si te asignan uno, borralo** |
+| ¿Puerto? | El 8000 | Ninguno |
+| Health check | Prendido, en `/salud` | **Apagado** |
+
+**El `Dockerfile` del repo corre el webhook de WhatsApp**, que es el caso que
+necesita servidor de verdad. Si querés desplegar el bot de Telegram, cambiale
+la última línea a `CMD ["python", "bot_telegram.py"]` y seguí la columna de la
+derecha. En los dos casos: **no levanta la plataforma de pruebas.**
 
 ```bash
-docker build -t agentkit-bot .
-docker run -d --env-file .env --name agentkit-bot agentkit-bot
+docker build -t agente .
+docker run -d --env-file .env -p 8000:8000 --name agente agente
 ```
 
 ### Con Coolify (o cualquier PaaS que lea un Dockerfile)
 
 1. Subí el código a un repositorio (privado está bien).
 2. Creá una aplicación de tipo **Dockerfile** apuntando a ese repo.
-3. **No le pongas dominio.** El bot no atiende visitas: no expone puerto y
-   ningún dominio le va a responder. Si el panel te asignó uno solo, borralo.
-4. Cargá las variables en el panel — **el `.env` no se sube al repo**:
+3. **Ponele el dominio** que va a usar el webhook, y dejá el puerto en `8000`.
+   (Si desplegás el bot de Telegram, este paso es al revés: sacale el dominio.)
+4. **Health check en `/salud`**, con el puerto 8000.
+5. Cargá las variables en el panel — **el `.env` no se sube al repo**:
 
    ```
-   PROVEEDOR · OPENAI_API_KEY · MODELO_OPENAI · TELEGRAM_TOKEN
+   PROVEEDOR · OPENAI_API_KEY · MODELO_OPENAI
    MODO=produccion · POSTGRES_DSN
    CACHE · MAX_TOKENS · MEMORIA_MENSAJES · PROMPT_SISTEMA
+   CHATWOOT_URL · CHATWOOT_TOKEN · CHATWOOT_CUENTA_ID
+   CHATWOOT_WEBHOOK_TOKEN · CHATWOOT_ETIQUETA_HUMANO · BUFFER_SEGUNDOS
    ```
 
-5. Desplegá.
+6. Desplegá, y entrá a `https://tu-dominio.com/salud` para confirmar.
 
-### Dos cosas para no comerte
+**Si la base de datos está en el mismo servidor**, usá el nombre interno del
+contenedor en el `POSTGRES_DSN` en vez de la IP pública: es más rápido y no
+sale a internet para volver a entrar.
 
-**Una sola instancia a la vez.** Si el bot queda corriendo en el servidor *y*
-en tu computadora, los dos le van a preguntar a Telegram por los mismos
-mensajes y se los van a repartir al azar: la mitad de las respuestas van a
-salir de una máquina y la otra mitad de la otra. Apagá el local antes.
+### Tres cosas para no comerte
 
 **`MODO=produccion`, o vas a perder las conversaciones.** En un contenedor,
 SQLite vive en el disco del contenedor, y ese disco se borra en cada deploy.
 Con Postgres la memoria sobrevive a los despliegues.
+
+**Si el panel te dice que el contenedor está *unhealthy* pero arranca bien,
+es `curl`.** El health check de un PaaS le pega a la URL **desde adentro** del
+contenedor, con `curl` o `wget`, y las imágenes `slim` de Python no traen
+ninguno de los dos. El contenedor levanta, atiende perfecto, y el panel lo da
+de baja igual con un *"New container is not healthy, rolling back"* que no
+menciona a `curl` por ningún lado. El `Dockerfile` de este repo ya lo instala;
+lo aclaramos porque se pierde un rato largo buscando el error en otro lado.
+
+**Una sola instancia a la vez, si usás Telegram.** Si el bot queda corriendo
+en el servidor *y* en tu computadora, los dos le van a preguntar a Telegram
+por los mismos mensajes y se los van a repartir al azar: la mitad de las
+respuestas van a salir de una máquina y la otra mitad de la otra. Apagá el
+local antes. (Con WhatsApp esto no pasa: los mensajes llegan a una URL, y esa
+URL es una sola.)
 
 ### Cómo actualizarlo después
 
@@ -578,6 +728,21 @@ la herramienta le sirve. Si está mal escrito, la herramienta no se usa nunca.
 | `MEMORIA_MENSAJES` | `20` | Cuántos mensajes recuerda |
 | `PROMPT_SISTEMA` | `prompts/sistema.md` | Qué archivo usar de personalidad |
 | `TELEGRAM_TOKEN` | — | El token de @BotFather, para `bot_telegram.py` |
+
+Y estas, solo si vas a atender WhatsApp con `webhook_chatwoot.py`:
+
+| Variable | Por defecto | Qué hace |
+|---|---|---|
+| `CHATWOOT_URL` | — | La dirección de tu Chatwoot, con `https://` |
+| `CHATWOOT_TOKEN` | — | El token de tu perfil de Chatwoot |
+| `CHATWOOT_CUENTA_ID` | `1` | El número que ves en la URL de Chatwoot |
+| `CHATWOOT_WEBHOOK_TOKEN` | — | El secreto que va en la URL del webhook |
+| `CHATWOOT_ETIQUETA_HUMANO` | `humano` | La etiqueta que apaga al bot en una conversación |
+| `BUFFER_SEGUNDOS` | `8` | Cuánto espera juntando la ráfaga antes de contestar |
+| `PUERTO` | `8000` | Dónde escucha el webhook |
+
+**No hace falta ninguna variable de Meta** (`WHATSAPP_TOKEN`, `APP_SECRET` y
+compañía): el agente le habla a Chatwoot, y Chatwoot es el que le habla a Meta.
 
 ---
 

--- a/src/agente/canales/buffer.py
+++ b/src/agente/canales/buffer.py
@@ -1,0 +1,125 @@
+"""Juntar la ráfaga de mensajes.
+
+La gente en WhatsApp no escribe un mensaje: escribe tres.
+
+    "hola"
+    "una consulta"
+    "por el precio del plan"
+
+Sin esto el agente contesta tres veces, y las tres mal: la primera no sabe
+nada, la segunda tampoco, y recién la tercera tiene la pregunta entera. Peor
+todavía, las tres respuestas se pisan entre sí en la pantalla del cliente.
+
+Con esto, el agente espera, junta lo que llegue y contesta **una sola vez**
+con todo junto.
+
+    "hola
+     una consulta
+     por el precio del plan"
+
+Cómo espera: cada mensaje nuevo reinicia el reloj (si sigue escribiendo,
+seguimos esperando), pero hay un tope duro. Sin ese tope, alguien que manda
+un mensaje cada tanto dejaría al agente esperando para siempre y nunca
+recibiría respuesta.
+
+Está en memoria a propósito. El AGENTS.md dice Redis, y va a hacer falta
+cuando haya más de un proceso atendiendo: hoy hay uno solo, y una ráfaga que
+se pierde si el contenedor se reinicia justo en esos segundos no justifica
+sumar una base entera. Cuando se escale a varios procesos, se cambia esta
+clase y nada más — el webhook no se entera.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+
+class BufferDeMensajes:
+    """Acumula los mensajes de cada conversación y avisa cuando paró la ráfaga."""
+
+    def __init__(
+        self,
+        segundos: float,
+        al_completar: Callable[[str, str], Awaitable[None]],
+        tope: float | None = None,
+    ) -> None:
+        """
+        `segundos`     cuánto se espera desde el último mensaje
+        `al_completar` qué hacer con la ráfaga junta: (conversacion, texto)
+        `tope`         cuánto se puede estirar la espera como máximo
+        """
+        self.segundos = max(0.0, float(segundos))
+        self.al_completar = al_completar
+
+        # El tope existe para el que escribe de a poco: sin él, un mensaje
+        # cada 50 segundos con una espera de 60 no se contesta nunca.
+        self.tope = float(tope) if tope is not None else self.segundos * 3
+
+        self._pendientes: dict[str, list[str]] = {}
+        self._relojes: dict[str, asyncio.Task] = {}
+        self._arrancó_en: dict[str, float] = {}
+
+    async def agregar(self, conversacion: str, texto: str) -> None:
+        """Suma un mensaje a la ráfaga de esa conversación."""
+        # Sin espera configurada no hay ráfaga que juntar: se contesta y listo.
+        if self.segundos <= 0:
+            await self.al_completar(conversacion, texto)
+            return
+
+        self._pendientes.setdefault(conversacion, []).append(texto)
+
+        ahora = asyncio.get_running_loop().time()
+        self._arrancó_en.setdefault(conversacion, ahora)
+
+        # El reloj anterior ya no sirve: llegó un mensaje nuevo y hay que
+        # volver a contar desde cero (salvo que ya nos pasamos del tope).
+        reloj = self._relojes.pop(conversacion, None)
+        if reloj is not None:
+            reloj.cancel()
+
+        gastado = ahora - self._arrancó_en[conversacion]
+        espera = min(self.segundos, max(0.0, self.tope - gastado))
+
+        self._relojes[conversacion] = asyncio.create_task(
+            self._esperar_y_soltar(conversacion, espera)
+        )
+
+    async def _esperar_y_soltar(self, conversacion: str, espera: float) -> None:
+        try:
+            await asyncio.sleep(espera)
+        except asyncio.CancelledError:
+            # Llegó otro mensaje: este reloj queda descartado y el nuevo se
+            # encarga. No hay nada que limpiar, los mensajes ya están juntos.
+            return
+
+        self._relojes.pop(conversacion, None)
+        self._arrancó_en.pop(conversacion, None)
+        partes = self._pendientes.pop(conversacion, [])
+
+        if not partes:
+            return
+
+        await self.al_completar(conversacion, "\n".join(partes))
+
+    def pendientes(self, conversacion: str) -> int:
+        """Cuántos mensajes hay esperando. Lo usan los tests y el /salud."""
+        return len(self._pendientes.get(conversacion, []))
+
+    async def vaciar(self) -> None:
+        """Suelta todo lo que esté esperando. Se llama al apagar el servidor.
+
+        Sin esto, un deploy en el momento justo se come la ráfaga de alguien
+        y esa persona se queda sin respuesta, sin que nadie se entere.
+        """
+        for reloj in list(self._relojes.values()):
+            reloj.cancel()
+        self._relojes.clear()
+        self._arrancó_en.clear()
+
+        pendientes = self._pendientes
+        self._pendientes = {}
+
+        for conversacion, partes in pendientes.items():
+            if partes:
+                await self.al_completar(conversacion, "\n".join(partes))

--- a/src/agente/canales/chatwoot.py
+++ b/src/agente/canales/chatwoot.py
@@ -1,0 +1,265 @@
+"""El canal de Chatwoot.
+
+Es el que atiende WhatsApp de verdad, pero no le habla a Meta: le habla a
+Chatwoot, que está en el medio. El recorrido completo de un mensaje es este:
+
+    persona → WhatsApp → Meta → Chatwoot → (webhook) → agente
+                                    ↑                     │
+                                    └───── API REST ──────┘
+
+Por qué con Chatwoot en el medio y no directo contra Meta:
+
+  · Queda el historial y la bandeja de entrada, con buscador.
+  · Una persona puede meterse en la conversación y seguirla a mano.
+  · El mismo agente atiende Instagram, el widget de la web o Telegram sin
+    tocar una línea: para nosotros todo entra por el mismo webhook.
+
+A diferencia de Telegram, acá **nadie sale a buscar los mensajes**: Chatwoot
+nos pega a una URL cuando pasa algo. Por eso esto necesita un servidor con
+dominio y HTTPS, y por eso el webhook vive en su propia app (web/webhook.py).
+
+El `conversacion` (el thread_id de LangGraph) es el **id de conversación de
+Chatwoot**. Es la misma unidad que ves en la bandeja: un hilo en la pantalla
+es un hilo de memoria del agente. También es lo que necesitamos para
+contestar, así que sirve para las dos cosas.
+
+Se usa `urllib`, de la biblioteca estándar, para no sumar una dependencia.
+La API de Chatwoot son pedidos HTTP con JSON: no hace falta más.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections import deque
+
+from .base import Canal, MensajeEntrante
+
+# Cuánto esperamos a que Chatwoot conteste. Corre en el mismo servidor que
+# el agente, así que si tarda más que esto es porque algo anda mal.
+ESPERA_DE_RED = 20
+
+
+class ErrorDeChatwoot(Exception):
+    """Chatwoot contestó algo que no esperábamos."""
+
+
+class Chatwoot(Canal):
+    """La bandeja de Chatwoot: por acá entran y salen los mensajes."""
+
+    nombre = "chatwoot"
+
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        cuenta_id: str | int,
+        etiqueta_humano: str = "humano",
+    ) -> None:
+        if not url or not token:
+            raise ValueError(
+                "Faltan datos de Chatwoot. Abrí el .env y completá "
+                "CHATWOOT_URL y CHATWOOT_TOKEN."
+            )
+
+        # La barra final sobra y duplicada rompe la URL ("...com//api/v1").
+        self.url = url.rstrip("/")
+        self.token = token
+        self.cuenta_id = str(cuenta_id)
+        self.etiqueta_humano = (etiqueta_humano or "").strip().lower()
+
+        # Los mensajes que ya contestamos. Chatwoot reintenta el webhook si no
+        # le respondemos rápido, y sin esto el agente contesta dos veces lo
+        # mismo. Alcanza con acordarse de los últimos.
+        self._ya_contestados: deque[str] = deque(maxlen=1000)
+
+    # -- Entrada ---------------------------------------------------------------
+
+    def traducir(self, evento: dict) -> MensajeEntrante | None:
+        """Convierte un evento del webhook en algo que el agente entiende.
+
+        Devuelve None si el evento no es un mensaje que tengamos que mirar:
+        otro tipo de evento, o un mensaje sin texto (un audio, una foto, un
+        adjunto suelto) que el agente todavía no sabe leer.
+        """
+        if evento.get("event") != "message_created":
+            return None
+
+        conversacion = evento.get("conversation") or {}
+        id_conversacion = conversacion.get("id")
+        texto = (evento.get("content") or "").strip()
+
+        if not id_conversacion or not texto:
+            return None
+
+        return MensajeEntrante(
+            texto=texto,
+            # El id de conversación es el thread_id: la memoria de cada
+            # persona por separado.
+            conversacion=str(id_conversacion),
+            identificador=str(evento.get("id") or ""),
+            datos=evento,
+        )
+
+    def deberia_responder(self, mensaje: MensajeEntrante) -> bool:
+        """Si el agente tiene que contestar este mensaje o dejarlo pasar.
+
+        Acá está casi toda la diferencia entre un bot de demo y uno que
+        atiende clientes de verdad. Son cuatro filtros y los cuatro importan:
+        """
+        evento = mensaje.datos
+
+        # 1. Solo los mensajes que ENTRAN. Los que salen son las respuestas
+        #    del propio agente y las de las personas del equipo. Sin este
+        #    filtro el agente se lee a sí mismo y se contesta para siempre:
+        #    es el error más caro de todos, porque cada vuelta gasta tokens.
+        if _tipo_de_mensaje(evento) != "incoming":
+            return False
+
+        # 2. Las notas privadas son para el equipo, no para el cliente. Si el
+        #    agente contestara ahí, mandaría al chat algo que era interno.
+        if evento.get("private"):
+            return False
+
+        # 3. El mismo mensaje dos veces. Chatwoot reintenta si el webhook no
+        #    contestó a tiempo, y el reintento trae el mismo id.
+        if mensaje.identificador and mensaje.identificador in self._ya_contestados:
+            return False
+
+        # 4. El traspaso a una persona. Si la conversación tiene la etiqueta,
+        #    el bot se calla: la está atendiendo alguien del equipo. Es *el*
+        #    diferencial de tener Chatwoot en el medio — se apaga con un clic
+        #    desde la bandeja, sin tocar el servidor.
+        if self._la_atiende_una_persona(evento):
+            return False
+
+        if mensaje.identificador:
+            self._ya_contestados.append(mensaje.identificador)
+
+        return True
+
+    def _la_atiende_una_persona(self, evento: dict) -> bool:
+        """Si la conversación está marcada con la etiqueta de traspaso."""
+        if not self.etiqueta_humano:
+            return False
+
+        conversacion = evento.get("conversation") or {}
+        etiquetas = conversacion.get("labels")
+
+        # Chatwoot manda las etiquetas en el evento casi siempre. Cuando no
+        # las manda (cambia entre versiones y entre tipos de evento) hay que
+        # preguntarle, porque dar por hecho que no hay ninguna sería dejar al
+        # bot hablando arriba de una persona.
+        if etiquetas is None:
+            etiquetas = self._etiquetas_de(conversacion.get("id"))
+
+        return self.etiqueta_humano in {
+            str(e).strip().lower() for e in etiquetas or []
+        }
+
+    def _etiquetas_de(self, id_conversacion) -> list[str]:
+        """Le pregunta a Chatwoot qué etiquetas tiene una conversación."""
+        if not id_conversacion:
+            return []
+
+        # Por qué se traga el error: si Chatwoot no contesta esta consulta, la
+        # alternativa es no responderle al cliente. Preferimos responder. El
+        # riesgo del otro lado (el bot habla arriba de una persona) existe,
+        # pero solo en el caso raro de que justo esta llamada falle.
+        try:
+            respuesta = self._api(
+                "GET", f"conversations/{id_conversacion}/labels"
+            )
+        except Exception:
+            return []
+
+        return respuesta.get("payload") or []
+
+    # -- Salida ----------------------------------------------------------------
+
+    def enviar(self, conversacion: str, mensajes: list[str]) -> None:
+        """Manda las respuestas a esa conversación, en orden.
+
+        Salen como `outgoing`, que es lo que Chatwoot entiende por "esto lo
+        dice nuestro lado". Desde ahí Chatwoot lo empuja al canal que
+        corresponda: WhatsApp, Instagram, el widget de la web.
+        """
+        for texto in mensajes:
+            if not texto.strip():
+                continue
+
+            self._api(
+                "POST",
+                f"conversations/{conversacion}/messages",
+                {"content": texto, "message_type": "outgoing"},
+            )
+
+    def escribiendo(self, conversacion: str, encendido: bool = True) -> None:
+        """El "escribiendo..." mientras el modelo piensa.
+
+        No es decorativo: una respuesta puede tardar varios segundos y sin
+        esto la persona no sabe si la escucharon o si se colgó.
+        """
+        # Que falle el aviso no puede voltear la respuesta: es cosmético.
+        try:
+            self._api(
+                "POST",
+                f"conversations/{conversacion}/toggle_typing_status",
+                {"typing_status": "on" if encendido else "off"},
+            )
+        except Exception:
+            pass
+
+    # -- La API ----------------------------------------------------------------
+
+    def yo_soy(self) -> dict:
+        """Los datos de la cuenta. Sirve para avisar al arrancar con cuál se habla."""
+        return self._api("GET", "conversations?status=open&page=1")
+
+    def _api(self, metodo: str, camino: str, datos: dict | None = None) -> dict:
+        """Una llamada a la API de Chatwoot."""
+        url = f"{self.url}/api/v1/accounts/{self.cuenta_id}/{camino}"
+
+        pedido = urllib.request.Request(
+            url,
+            data=json.dumps(datos).encode("utf-8") if datos is not None else None,
+            method=metodo,
+            headers={
+                "Content-Type": "application/json",
+                # Así se autentica Chatwoot: no es un Bearer, es este header.
+                "api_access_token": self.token,
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(pedido, timeout=ESPERA_DE_RED) as respuesta:
+                cuerpo = respuesta.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            # El cuerpo del error es lo único que dice qué pasó de verdad
+            # (token vencido, conversación que no existe, cuenta equivocada).
+            # Sin esto solo se ve "HTTP Error 404" y no se puede arreglar nada.
+            detalle = e.read().decode("utf-8", "replace")[:300]
+            raise ErrorDeChatwoot(
+                f"Chatwoot devolvió {e.code} en {metodo} {camino}: {detalle}"
+            ) from None
+
+        return json.loads(cuerpo) if cuerpo else {}
+
+
+# -- Ayudantes ----------------------------------------------------------------
+
+
+def _tipo_de_mensaje(evento: dict) -> str:
+    """Si el mensaje entra o sale.
+
+    Chatwoot lo manda como texto ("incoming"), pero según la versión y el
+    endpoint puede venir como número (0 = incoming, 1 = outgoing). Traducimos
+    los dos para que un cambio de versión no vuelva loco al bot.
+    """
+    tipo = evento.get("message_type")
+
+    if isinstance(tipo, int):
+        return {0: "incoming", 1: "outgoing"}.get(tipo, "otro")
+
+    return str(tipo or "").strip().lower()

--- a/src/agente/config.py
+++ b/src/agente/config.py
@@ -54,6 +54,20 @@ class Config:
     # de Telegram; el resto del proyecto ni lo mira.
     telegram_token: str = ""
 
+    # -- Chatwoot: solo lo mira el webhook (web/webhook.py) ------------------
+    chatwoot_url: str = ""
+    chatwoot_token: str = ""
+    chatwoot_cuenta_id: str = "1"
+    # La etiqueta que apaga al bot en una conversación: el traspaso a una
+    # persona. Se pone con un clic desde la bandeja de Chatwoot.
+    chatwoot_etiqueta_humano: str = "humano"
+    # El secreto que va en la URL del webhook. Chatwoot no firma sus pedidos,
+    # así que esto es lo único que separa un mensaje de verdad de cualquiera
+    # que haya descubierto el dominio.
+    chatwoot_webhook_token: str = ""
+    # Cuánto espera juntando la ráfaga antes de contestar (ver buffer.py).
+    buffer_segundos: int = 8
+
     @classmethod
     def desde_entorno(
         cls, proveedor: str | None = None, modelo: str | None = None
@@ -104,6 +118,16 @@ class Config:
             sqlite_ruta=os.getenv("SQLITE_RUTA", "datos/conversaciones.db"),
             postgres_dsn=(os.getenv("POSTGRES_DSN") or "").strip(),
             telegram_token=(os.getenv("TELEGRAM_TOKEN") or "").strip(),
+            chatwoot_url=(os.getenv("CHATWOOT_URL") or "").strip(),
+            chatwoot_token=(os.getenv("CHATWOOT_TOKEN") or "").strip(),
+            chatwoot_cuenta_id=(os.getenv("CHATWOOT_CUENTA_ID") or "1").strip(),
+            chatwoot_etiqueta_humano=(
+                os.getenv("CHATWOOT_ETIQUETA_HUMANO") or "humano"
+            ).strip(),
+            chatwoot_webhook_token=(
+                os.getenv("CHATWOOT_WEBHOOK_TOKEN") or ""
+            ).strip(),
+            buffer_segundos=_entero("BUFFER_SEGUNDOS", 8),
         )
 
 

--- a/src/agente/web/webhook.py
+++ b/src/agente/web/webhook.py
@@ -1,0 +1,170 @@
+"""El servidor que atiende WhatsApp.
+
+Esta es la app que corre en el servidor. **No es la plataforma de pruebas**
+(`web/app.py`): son dos cosas distintas y a propósito. La de pruebas es para
+tu máquina, tiene la pantalla con los ajustes y no sale de localhost. Esta no
+tiene pantalla: es una puerta por donde entra Chatwoot y nada más.
+
+Lo que hace, de punta a punta:
+
+    Chatwoot pega en POST /chatwoot/<token>
+      → contestamos 200 al toque              ← esto es obligatorio
+      → juntamos la ráfaga de mensajes          (buffer.py)
+      → responde el agente                      (agente.py)
+      → la respuesta sale por la API de Chatwoot (canales/chatwoot.py)
+
+**Por qué el 200 sale antes de responderle a la persona.** Chatwoot espera
+que el webhook conteste rápido; si tardamos lo que tarda el modelo en
+pensar, da el pedido por fallado y lo reintenta — y entonces el agente
+contesta dos veces lo mismo. Así que primero decimos "recibido" y recién
+después pensamos la respuesta, en segundo plano.
+
+**La seguridad es el token en la URL.** Chatwoot no firma sus webhooks (no
+hay HMAC como en Meta), así que lo único que separa un mensaje de verdad de
+cualquiera que descubra el dominio es que la URL tenga el token. Por eso es
+largo y por eso no va en el código.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from ..agente import Agente
+from ..canales.buffer import BufferDeMensajes
+from ..canales.chatwoot import Chatwoot
+from ..config import Config
+
+registro = logging.getLogger("agente.webhook")
+
+
+def crear_app(
+    config: Config | None = None,
+    agente: Agente | None = None,
+    canal: Chatwoot | None = None,
+) -> FastAPI:
+    """Arma el servidor.
+
+    El agente y el canal se pueden pasar armados: es lo que hacen los tests
+    para probar todo esto sin salir a internet ni gastar un token.
+    """
+    config = config or Config.desde_entorno()
+
+    canal = canal or Chatwoot(
+        url=config.chatwoot_url,
+        token=config.chatwoot_token,
+        cuenta_id=config.chatwoot_cuenta_id,
+        etiqueta_humano=config.chatwoot_etiqueta_humano,
+    )
+
+    # El agente se arma una sola vez y atiende a todo el mundo. Es lo que
+    # queremos: adentro tiene la conexión a Postgres, y armarlo por mensaje
+    # sería abrir una conexión nueva cada vez.
+    agente = agente or Agente(config)
+
+    # Un candado por conversación. Dos personas distintas se atienden a la
+    # vez sin problema, pero dos mensajes de la MISMA persona no: si se
+    # respondieran en paralelo, los dos leerían la memoria en el mismo punto
+    # y el segundo pisaría lo que guardó el primero.
+    candados: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    async def responder(conversacion: str, texto: str) -> None:
+        """Le pasa la ráfaga al agente y manda la respuesta por Chatwoot."""
+        async with candados[conversacion]:
+            registro.info("[%s] %s", conversacion, texto.replace("\n", " | ")[:200])
+
+            # El "escribiendo..." y el agente son código bloqueante (urllib y
+            # el modelo). Van a un hilo aparte para no trabar el servidor:
+            # mientras este mensaje se piensa, los demás siguen entrando.
+            await asyncio.to_thread(canal.escribiendo, conversacion, True)
+
+            try:
+                mensajes = await asyncio.to_thread(
+                    agente.responder_partido, texto, conversacion
+                )
+            except Exception as e:
+                # El error del proveedor no se esconde: se lo decimos a la
+                # persona y queda en los logs. Pero no volteamos el servidor,
+                # porque atiende a varias personas y una falla con una no
+                # puede dejar sin respuesta a las demás.
+                aviso = f"{type(e).__name__}: {e}"
+                registro.error("[%s] %s", conversacion, aviso)
+                mensajes = [f"Se me rompió algo: {aviso}"]
+
+            try:
+                await asyncio.to_thread(canal.enviar, conversacion, mensajes)
+            except Exception as e:
+                # Acá ya no hay a quién avisarle: el canal de salida es
+                # justamente el que falló. Queda en los logs.
+                registro.error("[%s] no se pudo enviar: %s", conversacion, e)
+            finally:
+                await asyncio.to_thread(canal.escribiendo, conversacion, False)
+
+            registro.info("[%s] -> %s mensaje(s)", conversacion, len(mensajes))
+
+    buffer = BufferDeMensajes(config.buffer_segundos, responder)
+
+    @asynccontextmanager
+    async def ciclo_de_vida(app: FastAPI):
+        registro.info(
+            "Agente escuchando - %s / %s - memoria %s - buffer %ss",
+            config.proveedor,
+            config.modelo,
+            "Postgres" if config.modo == "produccion" else "SQLite",
+            config.buffer_segundos,
+        )
+        yield
+        # Al apagar, soltamos lo que estaba esperando. Sin esto, un deploy
+        # justo en esos segundos se come la ráfaga de alguien.
+        await buffer.vaciar()
+
+    app = FastAPI(title="Agente - webhook de Chatwoot", lifespan=ciclo_de_vida)
+
+    # -- Las rutas -------------------------------------------------------------
+
+    @app.get("/salud")
+    async def salud() -> dict:
+        """Para que el servidor sepa que la app está viva.
+
+        Coolify le pega a esto cada tanto. Si no contesta, reinicia el
+        contenedor.
+        """
+        return {
+            "estado": "ok",
+            "proveedor": config.proveedor,
+            "modelo": config.modelo,
+            "memoria": "postgres" if config.modo == "produccion" else "sqlite",
+        }
+
+    @app.post("/chatwoot/{token}")
+    async def entrante(token: str, pedido: Request) -> JSONResponse:
+        """Por acá entra todo lo que manda Chatwoot."""
+        if not config.chatwoot_webhook_token or token != config.chatwoot_webhook_token:
+            # Sin detalles en la respuesta: al que probó la URL no le decimos
+            # si el token existe, si es corto o si le erró por una letra.
+            registro.warning("Llamada con token equivocado")
+            return JSONResponse({"error": "no autorizado"}, status_code=401)
+
+        try:
+            evento = await pedido.json()
+        except Exception:
+            return JSONResponse({"error": "esperaba JSON"}, status_code=400)
+
+        entrante = canal.traducir(evento)
+
+        if entrante is None or not canal.deberia_responder(entrante):
+            # No es un error: es la mayoría de lo que llega. Cada respuesta
+            # que manda el propio agente vuelve como un evento más.
+            return JSONResponse({"estado": "ignorado"})
+
+        # Se suma a la ráfaga y contestamos ya. Lo que sigue pasa solo.
+        await buffer.agregar(entrante.conversacion, entrante.texto)
+
+        return JSONResponse({"estado": "recibido"})
+
+    return app

--- a/tests/test_chatwoot.py
+++ b/tests/test_chatwoot.py
@@ -1,0 +1,429 @@
+"""Pruebas del canal de Chatwoot. No salen a internet ni gastan tokens.
+
+La API de Chatwoot se reemplaza por una de mentira que anota lo que se le
+pidió. Lo que se prueba es lo nuestro: qué mensajes se contestan, cuáles no,
+cómo se junta una ráfaga y qué sale para el otro lado.
+
+El test más importante de este archivo es
+`test_no_se_contesta_a_si_mismo`: sin ese filtro, cada respuesta del agente
+vuelve como un mensaje nuevo y el bot se responde solo para siempre,
+gastando tokens en cada vuelta.
+
+    pytest
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from agente.canales.buffer import BufferDeMensajes  # noqa: E402
+from agente.canales.chatwoot import Chatwoot, _tipo_de_mensaje  # noqa: E402
+
+
+def evento(
+    texto="hola",
+    conversacion=12,
+    id_mensaje=1,
+    tipo="incoming",
+    privado=False,
+    etiquetas=None,
+    nombre="message_created",
+) -> dict:
+    """Un mensaje como lo manda el webhook de Chatwoot."""
+    return {
+        "event": nombre,
+        "id": id_mensaje,
+        "content": texto,
+        "message_type": tipo,
+        "private": privado,
+        "conversation": {
+            "id": conversacion,
+            "status": "open",
+            "labels": [] if etiquetas is None else etiquetas,
+        },
+        "account": {"id": 1},
+        "inbox": {"id": 6, "name": "YT"},
+    }
+
+
+class ChatwootFalso(Chatwoot):
+    """El canal, pero con la API de mentira. Anota todo lo que se mandó."""
+
+    def __init__(self, etiqueta_humano="humano", etiquetas_remotas=None):
+        super().__init__(
+            url="https://chatwoot.ejemplo.com/",
+            token="token-falso",
+            cuenta_id=1,
+            etiqueta_humano=etiqueta_humano,
+        )
+        self.llamadas: list[dict] = []
+        self._etiquetas_remotas = etiquetas_remotas or []
+
+    def _api(self, metodo, camino, datos=None):
+        self.llamadas.append({"metodo": metodo, "camino": camino, "datos": datos})
+
+        if camino.endswith("/labels"):
+            return {"payload": self._etiquetas_remotas}
+        return {"id": 99}
+
+    def envios(self) -> list[str]:
+        """Solo los mensajes que salieron para la persona."""
+        return [
+            l["datos"]["content"]
+            for l in self.llamadas
+            if l["camino"].endswith("/messages") and l["datos"]
+        ]
+
+
+# -- Traducir lo que llega ----------------------------------------------------
+
+
+def test_traduce_un_mensaje_normal():
+    entrante = ChatwootFalso().traducir(evento("¿que clima hace?", conversacion=77, id_mensaje=42))
+
+    assert entrante is not None
+    assert entrante.texto == "¿que clima hace?"
+    assert entrante.conversacion == "77", "el id de conversación es el thread_id"
+    assert entrante.identificador == "42"
+
+
+def test_el_id_de_conversacion_va_como_texto():
+    """Es el thread_id de LangGraph, y ahí un 12 y un "12" no son lo mismo."""
+    entrante = ChatwootFalso().traducir(evento(conversacion=12))
+    assert isinstance(entrante.conversacion, str)
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    ["conversation_created", "conversation_status_changed", "webwidget_triggered"],
+)
+def test_los_otros_eventos_se_dejan_pasar(nombre):
+    """Chatwoot manda muchas cosas por el mismo webhook, no solo mensajes."""
+    assert ChatwootFalso().traducir(evento(nombre=nombre)) is None
+
+
+def test_un_mensaje_sin_texto_se_deja_pasar():
+    """Un audio o una foto sueltos: el agente todavía no sabe leer eso."""
+    assert ChatwootFalso().traducir(evento(texto="")) is None
+    assert ChatwootFalso().traducir(evento(texto="   ")) is None
+
+
+# -- Qué se contesta y qué no -------------------------------------------------
+
+
+def test_no_se_contesta_a_si_mismo():
+    """EL test de este archivo.
+
+    Cada respuesta que manda el agente vuelve por el webhook como un evento
+    nuevo, pero marcada como `outgoing`. Sin este filtro el agente la lee, la
+    contesta, esa respuesta vuelve otra vez… y así para siempre, gastando
+    tokens en cada vuelta.
+    """
+    canal = ChatwootFalso()
+    entrante = canal.traducir(evento("mi propia respuesta", tipo="outgoing"))
+
+    assert canal.deberia_responder(entrante) is False
+
+
+def test_no_contesta_las_notas_privadas():
+    """Una nota privada es para el equipo. Contestar ahí la manda al cliente."""
+    canal = ChatwootFalso()
+    entrante = canal.traducir(evento("ojo con este cliente", privado=True))
+
+    assert canal.deberia_responder(entrante) is False
+
+
+def test_no_contesta_dos_veces_el_mismo_mensaje():
+    """Chatwoot reintenta el webhook si no le contestamos a tiempo."""
+    canal = ChatwootFalso()
+    entrante = canal.traducir(evento(id_mensaje=7))
+
+    assert canal.deberia_responder(entrante) is True
+    assert canal.deberia_responder(entrante) is False, "la segunda vez ya no"
+
+
+def test_la_etiqueta_apaga_el_bot():
+    """El traspaso a una persona: se pone la etiqueta y el bot se calla."""
+    canal = ChatwootFalso()
+    entrante = canal.traducir(evento(etiquetas=["humano"]))
+
+    assert canal.deberia_responder(entrante) is False
+
+
+def test_la_etiqueta_no_distingue_mayusculas():
+    canal = ChatwootFalso()
+    assert canal.deberia_responder(canal.traducir(evento(etiquetas=["Humano"]))) is False
+
+
+def test_otras_etiquetas_no_lo_apagan():
+    canal = ChatwootFalso()
+    entrante = canal.traducir(evento(etiquetas=["ventas", "urgente"]))
+
+    assert canal.deberia_responder(entrante) is True
+
+
+def test_si_el_evento_no_trae_etiquetas_se_las_pregunta():
+    """Dar por hecho que no hay ninguna sería hablar arriba de una persona."""
+    canal = ChatwootFalso(etiquetas_remotas=["humano"])
+    crudo = evento()
+    del crudo["conversation"]["labels"]
+
+    assert canal.deberia_responder(canal.traducir(crudo)) is False
+    assert any(l["camino"].endswith("/labels") for l in canal.llamadas)
+
+
+def test_un_mensaje_normal_se_contesta():
+    canal = ChatwootFalso()
+    assert canal.deberia_responder(canal.traducir(evento())) is True
+
+
+@pytest.mark.parametrize(
+    "crudo,esperado",
+    [({"message_type": 0}, "incoming"), ({"message_type": 1}, "outgoing")],
+)
+def test_el_tipo_tambien_se_entiende_como_numero(crudo, esperado):
+    """Según la versión, Chatwoot lo manda como texto o como número."""
+    assert _tipo_de_mensaje(crudo) == esperado
+
+
+# -- Lo que sale --------------------------------------------------------------
+
+
+def test_envia_cada_mensaje_por_separado():
+    canal = ChatwootFalso()
+
+    canal.enviar("12", ["primero", "segundo"])
+
+    assert canal.envios() == ["primero", "segundo"]
+
+
+def test_lo_que_sale_va_marcado_como_outgoing():
+    """Si no, Chatwoot no lo empuja a WhatsApp y queda solo en la bandeja."""
+    canal = ChatwootFalso()
+
+    canal.enviar("12", ["hola"])
+
+    envio = [l for l in canal.llamadas if l["camino"].endswith("/messages")][0]
+    assert envio["datos"]["message_type"] == "outgoing"
+    assert envio["camino"] == "conversations/12/messages"
+
+
+def test_no_manda_mensajes_vacios():
+    canal = ChatwootFalso()
+
+    canal.enviar("12", ["hola", "   ", ""])
+
+    assert canal.envios() == ["hola"]
+
+
+def test_la_barra_final_de_la_url_no_se_duplica():
+    """Con "...com//api/v1" Chatwoot devuelve 404 y no se entiende por qué."""
+    canal = ChatwootFalso()
+    assert canal.url == "https://chatwoot.ejemplo.com"
+
+
+def test_el_escribiendo_no_voltea_la_respuesta(monkeypatch):
+    """Es cosmético: si falla, la respuesta tiene que salir igual."""
+    canal = ChatwootFalso()
+
+    def explota(*a, **k):
+        raise ConnectionError("se cayó")
+
+    monkeypatch.setattr(canal, "_api", explota)
+    canal.escribiendo("12")  # no tiene que levantar nada
+
+
+def test_sin_datos_avisa_que_faltan():
+    with pytest.raises(ValueError, match="CHATWOOT_URL"):
+        Chatwoot(url="", token="", cuenta_id=1)
+
+
+# -- Juntar la ráfaga ---------------------------------------------------------
+
+
+def juntar(buffer: BufferDeMensajes, mensajes, conversacion="12", entre=0.0):
+    """Manda varios mensajes seguidos y espera a que el buffer los suelte."""
+
+    async def correr():
+        for texto in mensajes:
+            await buffer.agregar(conversacion, texto)
+            if entre:
+                await asyncio.sleep(entre)
+        # Un rato más que la espera del buffer, para que llegue a soltar.
+        await asyncio.sleep(buffer.segundos + 0.15)
+
+    asyncio.run(correr())
+
+
+def test_tres_mensajes_seguidos_son_una_sola_respuesta():
+    """El caso de todos los días: "hola" / "una consulta" / "por el precio"."""
+    sueltos = []
+    buffer = BufferDeMensajes(
+        0.05, lambda c, t: _anotar(sueltos, c, t)
+    )
+
+    juntar(buffer, ["hola", "una consulta", "por el precio"])
+
+    assert len(sueltos) == 1, "tendría que haber contestado una sola vez"
+    assert sueltos[0] == ("12", "hola\nuna consulta\npor el precio")
+
+
+def test_cada_conversacion_junta_la_suya():
+    """Si se mezclaran, una persona recibiría el mensaje de otra."""
+    sueltos = []
+    buffer = BufferDeMensajes(0.05, lambda c, t: _anotar(sueltos, c, t))
+
+    async def correr():
+        await buffer.agregar("111", "soy uno")
+        await buffer.agregar("222", "soy dos")
+        await asyncio.sleep(0.25)
+
+    asyncio.run(correr())
+
+    assert sorted(sueltos) == [("111", "soy uno"), ("222", "soy dos")]
+
+
+def test_sin_espera_contesta_derecho():
+    """BUFFER_SEGUNDOS=0 apaga el buffer."""
+    sueltos = []
+    buffer = BufferDeMensajes(0, lambda c, t: _anotar(sueltos, c, t))
+
+    asyncio.run(buffer.agregar("12", "hola"))
+
+    assert sueltos == [("12", "hola")]
+
+
+def test_el_tope_corta_la_espera_infinita():
+    """Sin tope, alguien que escribe de a poco no recibe respuesta nunca.
+
+    Cada mensaje reinicia el reloj. Si la persona manda uno justo antes de
+    que se cumpla la espera, y otro, y otro, el agente se quedaría esperando
+    para siempre. El tope obliga a contestar igual.
+    """
+    sueltos = []
+    buffer = BufferDeMensajes(
+        0.20, lambda c, t: _anotar(sueltos, c, t), tope=0.30
+    )
+
+    # Seis mensajes cada 0,1s = 0,6s de charla. Con la espera de 0,2s
+    # reiniciándose cada vez, sin tope no soltaría hasta el final.
+    juntar(buffer, ["a", "b", "c", "d", "e", "f"], entre=0.1)
+
+    assert sueltos, "el tope tendría que haber forzado la respuesta"
+    assert len(sueltos[0][1].split("\n")) < 6, "soltó antes de que terminara"
+
+
+def test_al_apagar_no_se_pierde_lo_que_estaba_esperando():
+    """Un deploy justo en esos segundos dejaría a alguien sin respuesta."""
+    sueltos = []
+    buffer = BufferDeMensajes(30, lambda c, t: _anotar(sueltos, c, t))
+
+    async def correr():
+        await buffer.agregar("12", "hola")
+        assert buffer.pendientes("12") == 1
+        await buffer.vaciar()
+
+    asyncio.run(correr())
+
+    assert sueltos == [("12", "hola")]
+
+
+async def _anotar(donde, conversacion, texto):
+    donde.append((conversacion, texto))
+
+
+# -- El webhook entero, de punta a punta --------------------------------------
+#
+# Acá se pegan todas las piezas: llega el pedido de Chatwoot, contesta el
+# agente, sale la respuesta. Con un canal de mentira y un modelo de mentira,
+# así que no toca la red ni gasta un token.
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def cliente(canal, agente, token="secreto", buffer_segundos=0):
+    """Levanta el webhook con las piezas de mentira adentro."""
+    pytest.importorskip("httpx", reason="TestClient de FastAPI necesita httpx")
+    from fastapi.testclient import TestClient
+
+    from agente.web.webhook import crear_app
+
+    from test_agente import agente_falso  # noqa: F401  (deja src en sys.path)
+
+    config = agente.config
+    config.chatwoot_webhook_token = token
+    config.buffer_segundos = buffer_segundos
+
+    return TestClient(crear_app(config, agente=agente, canal=canal))
+
+
+def test_el_mensaje_da_la_vuelta_completa():
+    from test_agente import agente_falso
+
+    canal = ChatwootFalso()
+    agente = agente_falso(["¡Buenas! ¿En qué te ayudo?"])
+
+    with cliente(canal, agente) as web:
+        respuesta = web.post("/chatwoot/secreto", json=evento("hola", conversacion=55))
+
+    assert respuesta.status_code == 200
+    assert respuesta.json()["estado"] == "recibido"
+    assert canal.envios() == ["¡Buenas! ¿En qué te ayudo?"]
+
+
+def test_con_el_token_equivocado_no_entra():
+    """Es lo único que separa a Chatwoot de cualquiera que sepa el dominio."""
+    from test_agente import agente_falso
+
+    canal = ChatwootFalso()
+
+    with cliente(canal, agente_falso(["hola"])) as web:
+        respuesta = web.post("/chatwoot/no-es-este", json=evento())
+
+    assert respuesta.status_code == 401
+    assert canal.envios() == [], "no tiene que haber contestado nada"
+
+
+def test_su_propia_respuesta_no_dispara_otra():
+    """El ida y vuelta infinito, probado de punta a punta."""
+    from test_agente import agente_falso
+
+    canal = ChatwootFalso()
+    agente = agente_falso(["no debería usarse"])
+
+    with cliente(canal, agente) as web:
+        respuesta = web.post("/chatwoot/secreto", json=evento(tipo="outgoing"))
+
+    assert respuesta.json()["estado"] == "ignorado"
+    assert canal.envios() == []
+
+
+def test_si_el_modelo_falla_se_le_avisa_a_la_persona():
+    """Un error con una persona no puede dejarla esperando en silencio."""
+    from test_agente import agente_falso
+
+    canal = ChatwootFalso()
+    agente = agente_falso([])  # sin respuestas: el modelo falso revienta
+
+    with cliente(canal, agente) as web:
+        web.post("/chatwoot/secreto", json=evento("hola"))
+
+    assert len(canal.envios()) == 1
+    assert "rompió" in canal.envios()[0]
+
+
+def test_el_salud_contesta():
+    """Coolify le pega a esto; si no contesta, reinicia el contenedor."""
+    from test_agente import agente_falso
+
+    with cliente(ChatwootFalso(), agente_falso(["hola"])) as web:
+        respuesta = web.get("/salud")
+
+    assert respuesta.status_code == 200
+    assert respuesta.json()["estado"] == "ok"

--- a/webhook_chatwoot.py
+++ b/webhook_chatwoot.py
@@ -1,0 +1,77 @@
+"""El agente atendiendo WhatsApp, a través de Chatwoot.
+
+    python webhook_chatwoot.py
+
+Esto es lo que corre en el servidor. A diferencia del bot de Telegram, acá
+**no salimos a buscar los mensajes**: Chatwoot nos pega a una URL. Por eso
+necesita dominio y HTTPS, y por eso no sirve levantarlo en tu computadora
+salvo para probar que arranca.
+
+El recorrido completo:
+
+    persona → WhatsApp → Meta → Chatwoot → este servidor → agente
+                                    ↑                         │
+                                    └──────── respuesta ──────┘
+
+Antes de arrancar, en el .env:
+
+    CHATWOOT_URL, CHATWOOT_TOKEN, CHATWOOT_CUENTA_ID
+    CHATWOOT_WEBHOOK_TOKEN   ← el secreto que va en la URL del webhook
+
+Para cortar: Ctrl+C.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from agente.consola import preparar  # noqa: E402
+
+preparar()  # antes de imprimir nada, para que las tildes no rompan Windows
+
+import logging  # noqa: E402
+
+import uvicorn  # noqa: E402
+
+from agente import Config, ErrorDeConfiguracion  # noqa: E402
+from agente.web.webhook import crear_app  # noqa: E402
+
+AMBAR = "\033[38;5;214m"
+GRIS = "\033[90m"
+ROJO = "\033[91m"
+FIN = "\033[0m"
+
+
+def main() -> int:
+    # En el servidor los logs son lo único que se ve: sin esto, el panel
+    # queda mudo y no hay forma de saber si un mensaje llegó.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        config = Config.desde_entorno()
+        app = crear_app(config)
+    except (ErrorDeConfiguracion, ValueError) as e:
+        print(f"{ROJO}{e}{FIN}")
+        return 1
+
+    puerto = int(os.getenv("PUERTO", "8000"))
+
+    print(f"\n{AMBAR}Webhook escuchando{FIN} - puerto {puerto}")
+    print(f"{GRIS}   {config.proveedor} - {config.modelo}{FIN}")
+    print(f"{GRIS}   POST /chatwoot/<token>   ·   GET /salud{FIN}\n")
+
+    # host 0.0.0.0 porque adentro de un contenedor, escuchar solo en
+    # localhost es escuchar en un lugar al que nadie puede entrar.
+    uvicorn.run(app, host="0.0.0.0", port=puerto, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Cierra lo que el `AGENTS.md` tenía anotado como "Video 3 — WhatsApp".

```
persona → WhatsApp → Meta → Chatwoot → tu webhook → el agente
                               ↑                        │
                               └──── la respuesta ──────┘
```

**El agente no le habla a Meta: le habla a Chatwoot.** Esa decisión saca del
medio el token de WhatsApp, el App Secret y la verificación de firma HMAC —
de eso se encarga Chatwoot cuando conectás el inbox. A cambio quedan la
bandeja de entrada, el historial, y el traspaso a una persona con un clic.

## Lo que cambia

| | |
|---|---|
| `src/agente/canales/chatwoot.py` | nuevo · el canal: traduce el webhook y responde por la API |
| `src/agente/canales/buffer.py` | nuevo · junta la ráfaga de mensajes cortos |
| `src/agente/web/webhook.py` | nuevo · el servidor que corre en producción |
| `webhook_chatwoot.py` | nuevo · el punto de entrada |
| `tests/test_chatwoot.py` | nuevo · 33 tests |
| `src/agente/config.py` | +24 líneas, **0 borradas** |
| `Dockerfile` | ahora empaqueta el webhook y expone el 8000 |
| `README.md` · `.env.example` · `AGENTS.md` | documentación |

**`agente.py` no se tocó.** Sigue recibiendo texto y devolviendo texto: la
frontera del diseño aguantó un canal nuevo sin una línea de cambio. Tampoco se
tocaron `memoria.py`, `modelos.py`, `respuesta.py`, `telegram.py`, `base.py`,
la plataforma de pruebas ni los tests que ya estaban.

## Los cuatro filtros que importan

Es lo que separa una demo de algo que atiende gente:

1. **No contestarse a sí mismo.** Cada respuesta del agente vuelve por el
   webhook como un evento nuevo; solo se atienden los `incoming`. Sin ese
   filtro es un ida y vuelta infinito que gasta tokens en cada vuelta.
2. **No contestar notas privadas.** Son del equipo; contestarlas las mandaría
   al cliente.
3. **No repetir** cuando Chatwoot reintenta el mismo mensaje.
4. **Callarse** cuando alguien toma la conversación con la etiqueta.

## Documentación

Es la mitad del PR, porque los pasos manuales de Chatwoot no se pueden
adivinar leyendo el código:

- **README, sección nueva "Ponerlo en WhatsApp":** cómo sacar el token y la
  cuenta, armar el webhook con el secreto **en la URL**, suscribirlo **solo a
  `message_created`**, y crear la etiqueta `humano`.
- **README, deploy:** la sección decía lo contrario de lo que hay que hacer
  con un webhook (*"no le pongas dominio, health check apagado"* — eso vale
  para el bot de Telegram, que usa polling). Ahora están los dos casos en una
  tabla, porque son opuestos.
- **README:** por qué un contenedor sano aparece *unhealthy* — falta `curl` en
  las imágenes `slim`, y el log del panel no lo menciona.
- **`.env.example`:** las `CHATWOOT_*` dejan de estar comentadas, se suma
  `CHATWOOT_WEBHOOK_TOKEN`, y se van `REDIS_URL` y las cuatro `WHATSAPP_*`,
  que este camino no usa.

## Una decisión que cambia respecto de lo anotado

El `AGENTS.md` decía **Redis** para juntar la ráfaga. Quedó **en memoria**
(`canales/buffer.py`): Redis resolvía compartir la ráfaga entre varios
procesos y hoy hay uno solo atendiendo. Sumar una base entera para eso era
pagar un problema que todavía no existe. Cuando haya que escalar se cambia esa
clase y el webhook ni se entera. Está documentado en el `AGENTS.md`.

## Probado

- **103 tests** (33 nuevos), ninguno gasta tokens ni sale a internet.
- Desplegado y andando contra un WhatsApp real: mensajes entrando por Meta,
  el buffer juntando mensajes cortos seguidos y el agente respondiendo en la
  bandeja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)